### PR TITLE
Use more understandable cursor for pagination links

### DIFF
--- a/app.css
+++ b/app.css
@@ -157,3 +157,7 @@
   white-space: nowrap;
   margin-right: 5px;
 }
+
+.pagination__prev-button, .pagination__next-button {
+  cursor: pointer;
+}


### PR DESCRIPTION
Apologies for the PR for master.

This is a test to see if the owner has not completely abandoned the project after calling for contributors a year ago. The response (or lack thereof) received will determine how I interact with this project moving forward as I've had a very similar concept for a while.

The actual change makes clear to the user that the pagination arrows < and > are actually clickable rather than just being text (as the current cursor indicates).